### PR TITLE
Add SignUp Delay and LoadingLottie Screen(dim view)

### DIFF
--- a/app/src/main/java/com/mashup/damgledamgle/presentation/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/mashup/damgledamgle/presentation/feature/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.mashup.damgledamgle.presentation.feature.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
@@ -17,6 +18,7 @@ import androidx.navigation.NavHostController
 import com.airbnb.lottie.compose.*
 import com.mashup.damgledamgle.R
 import com.mashup.damgledamgle.presentation.common.BackPressInterceptor
+import com.mashup.damgledamgle.presentation.common.DisabledInteractionSource
 import com.mashup.damgledamgle.presentation.feature.home.bottomsheet.BottomSheetContent
 import com.mashup.damgledamgle.presentation.feature.home.map.MapScreen
 import com.mashup.damgledamgle.presentation.feature.toolbar.MainToolBar
@@ -127,6 +129,7 @@ fun LoadingLottie() {
             .fillMaxWidth()
             .fillMaxHeight()
             .background(LottieBackGround.copy(0.5F))
+            .clickable(interactionSource = DisabledInteractionSource(), indication = null) { },
     ) {
         LottieAnimation(
             modifier = Modifier

--- a/app/src/main/java/com/mashup/damgledamgle/presentation/feature/onboarding/NickNameScreen.kt
+++ b/app/src/main/java/com/mashup/damgledamgle/presentation/feature/onboarding/NickNameScreen.kt
@@ -15,6 +15,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.mashup.damgledamgle.R
 import com.mashup.damgledamgle.presentation.common.ViewState
+import com.mashup.damgledamgle.presentation.feature.home.LoadingLottie
 import com.mashup.damgledamgle.presentation.navigation.Screen
 import com.mashup.damgledamgle.ui.theme.*
 
@@ -33,6 +34,7 @@ fun NickNameScreen(
     val context = LocalContext.current
     val viewModel: OnboardingViewModel = hiltViewModel()
     val openNickNameErrorDialog = remember { mutableStateOf(false) }
+    val signUpLoadingState = remember { mutableStateOf(false) }
 
     Box(
         modifier = Modifier
@@ -122,9 +124,12 @@ fun NickNameScreen(
 
         LaunchedEffect(key1 = viewModel.authState.collectAsState().value) {
             when (viewModel.authState.value) {
-                is ViewState.Loading -> {}
+                is ViewState.Loading -> signUpLoadingState.value = true
                 is ViewState.Success -> navController.navigate(Screen.Home.route)
-                is ViewState.Error -> openNickNameErrorDialog.value = true
+                is ViewState.Error -> {
+                    signUpLoadingState.value = false
+                    openNickNameErrorDialog.value = true
+                }
             }
         }
     }
@@ -134,6 +139,10 @@ fun NickNameScreen(
             openNickNameErrorDialog = openNickNameErrorDialog,
             onButtonClick = { openNickNameErrorDialog.value = false }
         )
+    }
+
+    if (signUpLoadingState.value) {
+        LoadingLottie()
     }
 }
 

--- a/app/src/main/java/com/mashup/damgledamgle/presentation/feature/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/mashup/damgledamgle/presentation/feature/onboarding/OnboardingViewModel.kt
@@ -11,6 +11,7 @@ import com.mashup.damgledamgle.presentation.common.ViewState
 import com.mashup.damgledamgle.presentation.feature.onboarding.model.NickNameModel
 import com.mashup.damgledamgle.presentation.feature.onboarding.model.mapper.NickNameMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,8 +33,8 @@ class OnboardingViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<ViewState<*>>(ViewState.Loading)
     val uiState: StateFlow<ViewState<*>> = _uiState.asStateFlow()
 
-    private val _authState = MutableStateFlow<ViewState<User>>(ViewState.Loading)
-    val authState: StateFlow<ViewState<User>> = _authState.asStateFlow()
+    private val _authState = MutableStateFlow<ViewState<User>?>(null)
+    val authState: StateFlow<ViewState<User>?> = _authState.asStateFlow()
 
     val nickName = mutableStateOf(NickNameModel())
 
@@ -83,14 +84,17 @@ class OnboardingViewModel @Inject constructor(
                 is Result.Success -> {
                     when(val result = signUpUseCase(pickedNickNameResult.data.name, notification)) {
                         is Result.Success -> {
+                            delay(2000)
                             _authState.emit(ViewState.Success(result.data))
                         }
                         is Result.Error -> {
+                            delay(2000)
                             _authState.emit(ViewState.Error(result.exception.message.toString()))
                         }
                     }
                 }
                 is Result.Error -> {
+                    delay(2000)
                     _authState.emit(ViewState.Error(pickedNickNameResult.exception.message.toString()))
                 }
             }


### PR DESCRIPTION
- 닉네임 생성할 때 delay 2초 주고 그동안 로딩 로띠 돌리기
- 로딩 로띠 돌아갈 때 클릭해도 뒤에있는 버튼들 눌리지 않도록 처리